### PR TITLE
Make ezcmdliner-ppx compatible with ppxlib.0.18.0

### DIFF
--- a/clim-ppx.opam
+++ b/clim-ppx.opam
@@ -12,7 +12,7 @@ bug-reports: "https://github.com/Ninjapouet/clim/issues"
 depends: [
   "dune" {>= "2.7"}
   "clim" {= "0.3.0"}
-  "ppxlib" {>= "0.14.0"}
+  "ppxlib" {>= "0.18.0"}
   "fmt" {>= "0.8.8"}
   "cmdliner" {>= "1.0.4"}
   "odoc" {with-doc}

--- a/ppx/clim_ppx.ml
+++ b/ppx/clim_ppx.ml
@@ -128,7 +128,7 @@ let rec ocaml_doc : attributes -> (string * Location.t) option = function
   | {attr_name = {txt = name; _};
      attr_payload =
        PStr [{pstr_desc = Pstr_eval ({
-           pexp_desc = Pexp_constant (Pconst_string (doc_str, _)); _}, _); _}];
+           pexp_desc = Pexp_constant (Pconst_string (doc_str, _, _)); _}, _); _}];
      attr_loc} :: others ->
     if name = "ocaml.doc" then
       Some (doc_str, attr_loc)


### PR DESCRIPTION
ppxlib.0.18.0 upgrades its internal AST to 4.11 resulting in a change in string constant representation. This PR makes ezcmdliner-ppx compatible with the latest ppxlib.

You will probably want to wait for the ppxlib release to go through before merging this!